### PR TITLE
ref: use dart:mirrors instead of `Platform.script` to resolve uri

### DIFF
--- a/bin/installer_windows.dart
+++ b/bin/installer_windows.dart
@@ -3,13 +3,14 @@
 library installer_windows;
 
 import 'dart:io';
+import 'dart:mirrors';
 
 import 'package:yaml/yaml.dart';
 import 'package:path/path.dart' as path;
 import 'package:jinja/jinja.dart';
 
 final rootDir = path
-    .canonicalize(path.join(path.dirname(path.fromUri(Platform.script)), '..'));
+    .canonicalize(path.join(path.dirname(path.fromUri(currentMirrorSystem().findLibrary(#installer_windows).uri)), '..'));
 
 // NB: there has got to be a better way to do this
 final appDir = path.canonicalize(

--- a/bin/installer_windows.dart
+++ b/bin/installer_windows.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as path;
 import 'package:jinja/jinja.dart';
 
 final rootDir = path
-    .canonicalize(path.join(path.dirname(path.fromUri(currentMirrorSystem().findLibrary(#installer_windows).uri)), '..'));
+    .canonicalize(path.join(path.dirname(currentMirrorSystem().findLibrary(#installer_windows).uri.path), '..'));
 
 // NB: there has got to be a better way to do this
 final appDir = path.canonicalize(

--- a/bin/installer_windows.dart
+++ b/bin/installer_windows.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as path;
 import 'package:jinja/jinja.dart';
 
 final rootDir = path
-    .canonicalize(path.join(path.dirname(currentMirrorSystem().findLibrary(#installer_windows).uri.path), '..'));
+    .canonicalize(path.join(path.dirname(path.fromUri(currentMirrorSystem().findLibrary(#installer_windows).uri)), '..'));
 
 // NB: there has got to be a better way to do this
 final appDir = path.canonicalize(


### PR DESCRIPTION
Using `Platform.script` resolved a snapshot in the `.dart_tool\pub\bin\squirrel` directory, not the `installer_windows.dart` in the pub cache. This broke the program where it could not find the `vendor/` directory and other required files.

`dart:mirrors` resolves the correct path of `installer_windows.dart` when in the dart pub cache and `vendor` files are located properly.